### PR TITLE
refactor(server): 重构 KVNamespace 模拟方法

### DIFF
--- a/server/routers/dataHandler.js
+++ b/server/routers/dataHandler.js
@@ -1,21 +1,8 @@
 const express = require("express");
 const router = express.Router();
-const { readKVFile, writeKVFile, kvNamespaces } = require("../utils/kvUtils");
+const { kvNamespaces, createKVNamespace } = require("../utils/kvUtils");
 
-const DATA_FILE = kvNamespaces.DATA;
-
-// 模拟KVNamespace
-const KVNamespace = {
-  get: (key) => {
-    const data = readKVFile(DATA_FILE);
-    return data[key] || null;
-  },
-  put: (key, value) => {
-    const data = readKVFile(DATA_FILE);
-    data[key] = value;
-    writeKVFile(DATA_FILE, data);
-  },
-};
+const KVNamespace = createKVNamespace(kvNamespaces.DATA);
 
 router.post("/", async (req, res) => {
   try {

--- a/server/routers/loginHandler.js
+++ b/server/routers/loginHandler.js
@@ -1,21 +1,8 @@
 const express = require("express");
 const router = express.Router();
-const { readKVFile, writeKVFile, kvNamespaces } = require("../utils/kvUtils");
+const { kvNamespaces, createKVNamespace } = require("../utils/kvUtils");
 
-const USERS_FILE = kvNamespaces.USERS;
-
-// 模拟KVNamespace
-const KVNamespace = {
-  get: (key) => {
-    const data = readKVFile(USERS_FILE);
-    return data[key] || null;
-  },
-  put: (key, value) => {
-    const data = readKVFile(USERS_FILE);
-    data[key] = value;
-    writeKVFile(USERS_FILE, data);
-  },
-};
+const KVNamespace = createKVNamespace(kvNamespaces.USERS);
 
 router.post("/", async (req, res) => {
   try {

--- a/server/routers/qaHandler.js
+++ b/server/routers/qaHandler.js
@@ -1,32 +1,8 @@
 const express = require("express");
 const router = express.Router();
-const { readKVFile, writeKVFile, kvNamespaces } = require("../utils/kvUtils");
+const { kvNamespaces, createKVNamespace } = require("../utils/kvUtils");
 
-const QA_FILE = kvNamespaces.QA;
-
-// 模拟KVNamespace
-const KVNamespace = {
-  get: (key) => {
-    const data = readKVFile(QA_FILE);
-    return data[key] || null;
-  },
-  put: (key, value) => {
-    const data = readKVFile(QA_FILE);
-    data[key] = value;
-    writeKVFile(QA_FILE, data);
-  },
-  delete: (key) => {
-    const data = readKVFile(QA_FILE);
-    delete data[key];
-    writeKVFile(QA_FILE, data);
-  },
-  list: () => {
-    const data = readKVFile(QA_FILE);
-    return {
-      keys: Object.keys(data).map((key) => ({ name: key })),
-    };
-  },
-};
+const KVNamespace = createKVNamespace(kvNamespaces.QA);
 
 router.post("/", async (req, res) => {
   try {

--- a/server/routers/signUpHandler.js
+++ b/server/routers/signUpHandler.js
@@ -1,27 +1,8 @@
 const express = require("express");
 const router = express.Router();
-const { readKVFile, writeKVFile, kvNamespaces } = require("../utils/kvUtils");
+const { kvNamespaces, createKVNamespace } = require("../utils/kvUtils");
 
-const PART_LIST_FILE = kvNamespaces.PART_LIST;
-
-// 模拟KVNamespace
-const KVNamespace = {
-  get: (key) => {
-    const data = readKVFile(PART_LIST_FILE);
-    return data[key] || null;
-  },
-  put: (key, value) => {
-    const data = readKVFile(PART_LIST_FILE);
-    data[key] = value;
-    writeKVFile(PART_LIST_FILE, data);
-  },
-  list: () => {
-    const data = readKVFile(PART_LIST_FILE);
-    return {
-      keys: Object.keys(data).map((key) => ({ name: key })),
-    };
-  },
-};
+const KVNamespace = createKVNamespace(kvNamespaces.PART_LIST);
 
 router.post("/", async (req, res) => {
   try {

--- a/server/routers/voteHandler.js
+++ b/server/routers/voteHandler.js
@@ -1,32 +1,8 @@
 const express = require("express");
 const router = express.Router();
-const { readKVFile, writeKVFile, kvNamespaces } = require("../utils/kvUtils");
+const { kvNamespaces, createKVNamespace } = require("../utils/kvUtils");
 
-const VOTE_FILE = kvNamespaces.VOTE;
-
-// 模拟KVNamespace
-const KVNamespace = {
-  get: (key) => {
-    const data = readKVFile(VOTE_FILE);
-    return data[key] || null;
-  },
-  put: (key, value) => {
-    const data = readKVFile(VOTE_FILE);
-    data[key] = value;
-    writeKVFile(VOTE_FILE, data);
-  },
-  delete: (key) => {
-    const data = readKVFile(VOTE_FILE);
-    delete data[key];
-    writeKVFile(VOTE_FILE, data);
-  },
-  list: () => {
-    const data = readKVFile(VOTE_FILE);
-    return {
-      keys: Object.keys(data).map((key) => ({ name: key })),
-    };
-  },
-};
+const KVNamespace = createKVNamespace(kvNamespaces.VOTE);
 
 router.post("/", async (req, res) => {
   try {

--- a/server/utils/kvUtils.js
+++ b/server/utils/kvUtils.js
@@ -3,7 +3,6 @@ const path = require("path");
 
 const DATA_DIR = path.join(__dirname, "..", "data");
 
-// 初始化KV命名空间文件
 const kvNamespaces = {
   DATA: "data.json",
   USERS: "users.json",
@@ -13,19 +12,51 @@ const kvNamespaces = {
   VOTE: "vote.json",
 };
 
+const readKVFile = (fileName) => {
+  const filePath = path.join(DATA_DIR, fileName);
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+};
+
+const writeKVFile = (fileName, data) => {
+  const filePath = path.join(DATA_DIR, fileName);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+};
+
+const createKVNamespace = (namespace) => {
+  return {
+    get: (key) => {
+      const data = readKVFile(namespace);
+      return data[key] || null;
+    },
+    put: (key, value) => {
+      const data = readKVFile(namespace);
+      data[key] = value;
+      writeKVFile(namespace, data);
+    },
+    delete: (key) => {
+      const data = readKVFile(namespace);
+      delete data[key];
+      writeKVFile(namespace, data);
+    },
+    list: () => {
+      const data = readKVFile(namespace);
+      return {
+        keys: Object.keys(data).map((key) => ({ name: key })),
+      };
+    },
+  };
+};
+
 module.exports = {
   // 读取KV文件
-  readKVFile(fileName) {
-    const filePath = path.join(DATA_DIR, fileName);
-    return JSON.parse(fs.readFileSync(filePath, "utf8"));
-  },
+  readKVFile,
 
   // 写入KV文件
-  writeKVFile(fileName, data) {
-    const filePath = path.join(DATA_DIR, fileName);
-    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
-  },
+  writeKVFile,
 
   // KV命名空间文件
   kvNamespaces,
+
+  // 创建KVNamespace模拟方法
+  createKVNamespace,
 };


### PR DESCRIPTION
- 新增 createKVNamespace 函数，用于创建 KVNamespace 模拟对象
- 修改各路由处理器，使用新的 createKVNamespace 函数创建 KVNamespace
- 优化了代码结构，提高了代码的可维护性和可重用性